### PR TITLE
Added 'toParents' method to EmbedsMany relationship.

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -339,4 +339,25 @@ class EmbedsMany extends EmbedsOneOrMany
     {
         return 'whereIn';
     }
+
+    /**
+     * Gets the embedded children in their full models
+     *
+     * @inheritdoc
+     */
+    public function toParents()
+    {
+        $parent_model      = $this->parent;
+        $relationship      = $this->relation;
+        $embedded_children = $parent_model->{$relationship};
+        $first_child       = $embedded_children->first();
+
+        if($first_child && $first_child->parentModel()) {
+            $related_parent_class = get_class($first_child->parentModel()->related);
+
+            return $related_parent_class::whereIn('_id', $embedded_children->pluck('_id'))->get();
+        }
+
+        return collect();
+    }
 }


### PR DESCRIPTION
Added new method to the EmbedsMany relationship called 'toParents' this method allows us to get all of the parents of an embedsMany relationship at a single query instead of having to loop through each model and use $model->parentModel; this allows us to just do $model->embedsManyRelationship()->toParents(); and it will return a collection of the parent models contained within the embedsMany relationship.